### PR TITLE
Block setViewState events coming from outlets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2016-03-31
+
+### Added
+
+- Throw an error if a plugin call `setViewState`
 
 ## [1.0.0] - 2016-03-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Throw an error if a plugin call `setViewState`
+- Block `setViewState` from plugins
 
 ## [1.0.0] - 2016-03-16
 

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ ShellSdk provide a set of features which are specifically designed to allow comm
 
   - #### VIEW STATE : an all instance synced data object
 
-	You might need to share between your application and plugins a general context to provide coherent UI. ShellSdk let you share any `{ key: value }` object through the ViewState entity. You can define a key from any application or any plugin using the `setViewState` method. ViewState is not persistent and will be deleted when user navigate outside of the application.
+	You might need to share between your application and plugins a general context to provide consistent UI. ShellSdk let applications share any `{ key: value }` object through the ViewState entity. You can update the using the `setViewState(key, value)` method. ViewState is not persistent and will be deleted when user navigate outside of the application. ViewState is not allowed to use in a plugin for security reason, and will throw generic error object.
 	
 	``` typescript
 	this.sdk.setViewState('TECHNICIAN', id);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fsm-shell",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "client library for FSM shell",
   "main": "release/fsm-shell-client.js",
   "module": "release/fsm-shell-client.es.js",

--- a/src/ShellSdk.ts
+++ b/src/ShellSdk.ts
@@ -181,6 +181,9 @@ export class ShellSdk {
       if (source) { // If has a source, we look if it come from one of our HTMLIFrameElement
         const iFrameElement = Array.from(this.outletsMap.keys()).find(frame => frame.contentWindow === source);
         if (iFrameElement) {  // If it come from an outlet
+          if (payload.type == SHELL_EVENTS.Version1.SET_VIEW_STATE) {
+            throw new Error('[ShellSDk] A plugin tried to update viewState using SetViewState which is not allowed for security reason.');
+          }
           const uuid = this.outletsMap.get(iFrameElement);
           let from = payload.from || [];
           if (uuid) {


### PR DESCRIPTION
Because of security issues, setViewState is no longer possible from an outlet but only from the main application. This PR update ShellSdk lib accordingly.

https://jira.coresystems.net/browse/CPB-47147