### PR TITLE
Add getter fror target object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.1] - 2020-06-17
+
+### Added
+
+- `getTarget()` method to access ShellSdk target object
+
 ## [1.5.0] - 2020-06-05
 
 ### Added
@@ -22,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bugfix
 
-- Fix `.join` crash on  `GET_STORAGE_ITEM` event. from shell-host
+- Fix `.join` crash on `GET_STORAGE_ITEM` event. from shell-host
 
 ## [1.3.1] - 2020-05-11
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fsm-shell",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "client library for FSM shell",
   "main": "release/fsm-shell-client.js",
   "module": "release/fsm-shell-client.es.js",

--- a/src/ShellSdk.spec.ts
+++ b/src/ShellSdk.spec.ts
@@ -1,10 +1,8 @@
-
 import { ShellSdk } from './ShellSdk';
 import { SHELL_EVENTS } from './ShellEvents';
 import * as sinon from 'sinon';
 
 describe('Shell Sdk', () => {
-
   let sdk: ShellSdk;
   let sdkTarget: any;
   let sdkOrigin: string;
@@ -20,14 +18,14 @@ describe('Shell Sdk', () => {
       addEventListener: (eventType, callback) => {
         windowMockEventListenerAdded = true;
         windowMockEventType = eventType;
-        windowMockCallback = callback
-      }
-    }
+        windowMockCallback = callback;
+      },
+    };
 
     sdkOrigin = 'fsm-sdk.net';
 
     sdkTarget = {
-      postMessage: sinon.stub()
+      postMessage: sinon.stub(),
     };
     data = { message: 'test' };
   });
@@ -36,9 +34,8 @@ describe('Shell Sdk', () => {
     sdk = ShellSdk.init(sdkTarget, sdkOrigin, windowMock);
     expect(sdk).toBeDefined();
   });
-
   it('should create instance as Root', () => {
-    sdk = ShellSdk.init(null as any as Window, sdkOrigin, windowMock);
+    sdk = ShellSdk.init((null as any) as Window, sdkOrigin, windowMock);
     expect(sdk).toBeDefined();
   });
 
@@ -46,6 +43,11 @@ describe('Shell Sdk', () => {
     sdk = ShellSdk.init(sdkTarget, sdkOrigin, windowMock);
     const sdkCopy = ShellSdk.instance;
     expect(sdk).toEqual(sdkCopy);
+  });
+
+  it('should return target using getTarget', () => {
+    sdk = ShellSdk.init(sdkTarget, sdkOrigin, windowMock);
+    expect(sdk.getTarget()).toBe(sdkTarget);
   });
 
   it('should post message on emit', () => {
@@ -65,7 +67,7 @@ describe('Shell Sdk', () => {
     sdk = ShellSdk.init(sdkTarget, sdkOrigin, windowMock);
     expect(windowMockEventListenerAdded).toBe(true);
     expect(windowMockEventType).toBe('message'),
-    expect(windowMockCallback).toBeDefined();
+      expect(windowMockCallback).toBeDefined();
   });
 
   it('should call subscriber on message event', (done) => {
@@ -78,9 +80,9 @@ describe('Shell Sdk', () => {
       data: {
         type: SHELL_EVENTS.Version1.REQUIRE_CONTEXT,
         value: {
-          message: 'test data'
-        }
-      }
+          message: 'test data',
+        },
+      },
     });
   });
 
@@ -102,9 +104,9 @@ describe('Shell Sdk', () => {
       data: {
         type: SHELL_EVENTS.Version1.REQUIRE_CONTEXT,
         value: {
-          message: 'test data'
-        }
-      }
+          message: 'test data',
+        },
+      },
     });
 
     expect(handler1Called).toBe(true);
@@ -130,9 +132,9 @@ describe('Shell Sdk', () => {
       data: {
         type: SHELL_EVENTS.Version1.REQUIRE_CONTEXT,
         value: {
-          message: 'test data'
-        }
-      }
+          message: 'test data',
+        },
+      },
     });
 
     expect(handler1Called).toBe(false);
@@ -141,9 +143,13 @@ describe('Shell Sdk', () => {
 
   it('should confirm context with request_context_done event', () => {
     const postMessageParent = sinon.spy();
-    sdk = ShellSdk.init({
-      postMessage: postMessageParent
-    } as any as Window, sdkOrigin, windowMock);
+    sdk = ShellSdk.init(
+      ({
+        postMessage: postMessageParent,
+      } as any) as Window,
+      sdkOrigin,
+      windowMock
+    );
 
     const requestContext = sinon.spy();
 
@@ -154,8 +160,8 @@ describe('Shell Sdk', () => {
         type: SHELL_EVENTS.Version1.REQUIRE_CONTEXT,
         value: {
           message: 'test data',
-        }
-      }
+        },
+      },
     });
 
     expect(requestContext.called).toBe(true);
@@ -168,8 +174,8 @@ describe('Shell Sdk', () => {
 
     sdk = ShellSdk.init(sdkTarget, sdkOrigin, windowMock);
 
-    sdk.onViewState('TECHNICIAN', id => technicianId = id);
-    sdk.onViewState('SERVICECALL', id => servicecallId = id);
+    sdk.onViewState('TECHNICIAN', (id) => (technicianId = id));
+    sdk.onViewState('SERVICECALL', (id) => (servicecallId = id));
 
     windowMockCallback({
       data: {
@@ -177,11 +183,11 @@ describe('Shell Sdk', () => {
         value: {
           message: 'test data',
           viewState: {
-            'TECHNICIAN': 42,
-            'SERVICECALL': 1337
-          }
-        }
-      }
+            TECHNICIAN: 42,
+            SERVICECALL: 1337,
+          },
+        },
+      },
     });
 
     expect(technicianId).toEqual(42);
@@ -190,9 +196,13 @@ describe('Shell Sdk', () => {
 
   it('should trigger onViewState after request_context then send to parent loading_success', () => {
     const postMessageParent = sinon.spy();
-    sdk = ShellSdk.init({
-      postMessage: postMessageParent
-    } as any as Window, sdkOrigin, windowMock);
+    sdk = ShellSdk.init(
+      ({
+        postMessage: postMessageParent,
+      } as any) as Window,
+      sdkOrigin,
+      windowMock
+    );
 
     const requestContext = sinon.spy();
 
@@ -210,11 +220,11 @@ describe('Shell Sdk', () => {
         value: {
           message: 'test data',
           viewState: {
-            'TECHNICIAN': 42,
-            'SERVICECALL': 1337
-          }
-        }
-      }
+            TECHNICIAN: 42,
+            SERVICECALL: 1337,
+          },
+        },
+      },
     });
 
     expect(requestContext.called).toBe(true);
@@ -230,20 +240,21 @@ describe('Shell Sdk', () => {
 
   it('should only accept events from allowedOrigins', () => {
     const postMessageParent = sinon.spy();
-    sdk = ShellSdk.init({
-      postMessage: postMessageParent
-    } as any as Window, sdkOrigin, windowMock);
+    sdk = ShellSdk.init(
+      ({
+        postMessage: postMessageParent,
+      } as any) as Window,
+      sdkOrigin,
+      windowMock
+    );
 
-    sdk.setAllowedOrigins([
-      'https://s1.exemple.com',
-      'https://s2.exemple.com'
-    ]);
+    sdk.setAllowedOrigins(['https://s1.exemple.com', 'https://s2.exemple.com']);
 
     const data = {
       type: SHELL_EVENTS.Version1.REQUIRE_CONTEXT,
       value: {
-        message: 'test data'
-      }
+        message: 'test data',
+      },
     };
 
     const requestContext = sinon.spy();
@@ -288,5 +299,4 @@ describe('Shell Sdk', () => {
     expect(requestContext.called).toBe(true);
     requestContext.resetHistory();
   });
-
 });

--- a/src/ShellSdk.ts
+++ b/src/ShellSdk.ts
@@ -1,11 +1,11 @@
-
 import { EventType, ErrorType, SHELL_EVENTS } from './ShellEvents';
 import { SHELL_VERSION_INFO } from './ShellVersionInfo';
 import { Debugger } from './Debugger';
 
 function uuidv4() {
-  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
-    var r = Math.random() * 16 | 0, v = c == 'x' ? r : (r & 0x3 | 0x8);
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
+    var r = (Math.random() * 16) | 0,
+      v = c == 'x' ? r : (r & 0x3) | 0x8;
     return v.toString(16);
   });
 }
@@ -13,17 +13,18 @@ function uuidv4() {
 const DEFAULT_MAXIMUM_DEPTH = 1;
 
 export class ShellSdk {
-
   public static VERSION = SHELL_VERSION_INFO.VERSION;
   public static BUILD_TS = SHELL_VERSION_INFO.BUILD_TS;
 
   private static _instance: ShellSdk;
   private isRoot: boolean; // Is root if on `init`, target value is null.
 
-  private postMessageHandler: (<T>(type: EventType, value: T, to?: string[]) => void) | undefined;
+  private postMessageHandler:
+    | (<T>(type: EventType, value: T, to?: string[]) => void)
+    | undefined;
 
-  private subscribersMap: Map<EventType, Function[]>
-  private subscribersViewStateMap: Map<string, Function[]>
+  private subscribersMap: Map<EventType, Function[]>;
+  private subscribersViewStateMap: Map<string, Function[]>;
 
   private debugger: Debugger;
   private outletsMap: Map<HTMLIFrameElement, string>;
@@ -45,14 +46,26 @@ export class ShellSdk {
     this.isRoot = target == null;
   }
 
-  public static init(target: Window, origin: string, winRef: Window = window, debugId: string = '', outletMaximumDepth: number = DEFAULT_MAXIMUM_DEPTH): ShellSdk {
-    ShellSdk._instance = new ShellSdk(target, origin, winRef, debugId, outletMaximumDepth);
+  public static init(
+    target: Window,
+    origin: string,
+    winRef: Window = window,
+    debugId: string = '',
+    outletMaximumDepth: number = DEFAULT_MAXIMUM_DEPTH
+  ): ShellSdk {
+    ShellSdk._instance = new ShellSdk(
+      target,
+      origin,
+      winRef,
+      debugId,
+      outletMaximumDepth
+    );
     return ShellSdk._instance;
   }
 
   public static get instance(): ShellSdk {
     if (!ShellSdk._instance) {
-      throw new Error('ShellSdk wasn\'t initialized.');
+      throw new Error("ShellSdk wasn't initialized.");
     }
     return ShellSdk._instance;
   }
@@ -62,7 +75,7 @@ export class ShellSdk {
   }
 
   public setAllowedOrigins(allowedOrigins: string[] | '*' = []) {
-      this.allowedOrigins = allowedOrigins === '*' ? [] : allowedOrigins;
+    this.allowedOrigins = allowedOrigins === '*' ? [] : allowedOrigins;
   }
 
   // Called by outlet component to assign an generated uuid to an iframe. This is key
@@ -73,6 +86,10 @@ export class ShellSdk {
 
   public unregisterOutlet(frame: HTMLIFrameElement) {
     this.outletsMap.delete(frame);
+  }
+
+  public getTarget() {
+    return this.target;
   }
 
   public setTarget(target: Window, origin: string) {
@@ -92,7 +109,7 @@ export class ShellSdk {
     return () => {
       this.removeSubscriber(type, subscriber);
     };
-  }
+  };
 
   public onViewState = (key: string, subscriber: Function): Function => {
     if (!this.subscribersViewStateMap.has(key)) {
@@ -102,88 +119,106 @@ export class ShellSdk {
     subscribers.push(subscriber);
     return () => {
       this.removeViewStateSubscriber(key, subscriber);
-    }
-  }
+    };
+  };
 
   public off = (type: EventType, subscriber: Function): void => {
     this.removeSubscriber(type, subscriber);
-  }
+  };
 
   public offViewState = (key: string, subscriber: Function): void => {
     this.removeViewStateSubscriber(key, subscriber);
-  }
+  };
 
   public emit<T>(type: EventType, value: T, to?: string[]) {
     if (!this.postMessageHandler) {
-      throw new Error('ShellSdk wasn\'t initialized, message handler not set.');
+      throw new Error("ShellSdk wasn't initialized, message handler not set.");
     }
-    // Only root can send a message to a specific node 
+    // Only root can send a message to a specific node
     this.postMessageHandler(type, value, this.isRoot ? to : undefined);
   }
 
   public setViewState(key: string, value: any) {
     if (!this.postMessageHandler) {
-      throw new Error('ShellSdk wasn\'t initialized, message handler not set.');
+      throw new Error("ShellSdk wasn't initialized, message handler not set.");
     }
-    this.postMessageHandler(SHELL_EVENTS.Version1.SET_VIEW_STATE, { key, value });
+    this.postMessageHandler(SHELL_EVENTS.Version1.SET_VIEW_STATE, {
+      key,
+      value,
+    });
   }
 
   private removeSubscriber(type: EventType, subscriber: Function) {
     const subscribers = this.subscribersMap.get(type);
     if (!!subscribers) {
-      this.subscribersMap.set(type, subscribers.filter(it => it !== subscriber));
+      this.subscribersMap.set(
+        type,
+        subscribers.filter((it) => it !== subscriber)
+      );
     }
   }
 
   private removeViewStateSubscriber(type: string, subscriber: Function) {
     const subscribers = this.subscribersViewStateMap.get(type);
     if (!!subscribers) {
-      this.subscribersViewStateMap.set(type, subscribers.filter(it => it !== subscriber));
+      this.subscribersViewStateMap.set(
+        type,
+        subscribers.filter((it) => it !== subscriber)
+      );
     }
   }
 
   private initMessageApi() {
-    this.postMessageHandler = (<T>(type: EventType, value: T, to?: string[]) => {
+    this.postMessageHandler = <T>(type: EventType, value: T, to?: string[]) => {
       if (!this.target) {
-        throw new Error('ShellSdk wasn\'t initialized, target is missing.');
+        throw new Error("ShellSdk wasn't initialized, target is missing.");
       }
       if (!this.origin) {
-        throw new Error('ShellSdk wasn\'t initialized, origin is missing.');
+        throw new Error("ShellSdk wasn't initialized, origin is missing.");
       }
 
       this.debugger.traceEvent('outgoing', type, value, { to }, true);
       this.target.postMessage({ type, value, to }, this.origin);
-    });
+    };
     this.winRef.addEventListener('message', this.onMessage);
   }
 
   /*
     Message handler, generic for all ShellSDK instances but have different behaviours if root of not.
-  
+
     - If root, we handle all messages to subscribers
-    - If not root, and receive a message from an iframe registered as outlet, we send to parent node 
+    - If not root, and receive a message from an iframe registered as outlet, we send to parent node
     and add node's id to allow return if needed.
     - If not root and receive SET_VIEW_STATE, we set new value on local node and propagate to outlets
     - If not root and receive TO_APP, we handle locally and do not propagate to outlets
     - If not root and receive any message with `to` value, we remove our id and send to destination
 
-    Also define a new event for REQUIRE_CONTEXT which now contains ViewState. To use ViewState binding 
+    Also define a new event for REQUIRE_CONTEXT which now contains ViewState. To use ViewState binding
     and avoid duplicate key we first provide REQUIRE_CONTEXT to init currrent node, then propagate each
     key of ViewState individualy to match potential subscriptions. To avoid UI glitch after this we
-    send an empty REQUIRE_CONTEXT_DONE to eventually adjust UI if needed.  
+    send an empty REQUIRE_CONTEXT_DONE to eventually adjust UI if needed.
   */
   private onMessage = (event: MessageEvent) => {
-
     if (!event.data || typeof event.data.type !== 'string') {
       return;
     }
 
-    if (this.allowedOrigins && Array.isArray(this.allowedOrigins) && this.allowedOrigins.length != 0 && this.allowedOrigins.indexOf(event.origin) === -1) {
+    if (
+      this.allowedOrigins &&
+      Array.isArray(this.allowedOrigins) &&
+      this.allowedOrigins.length != 0 &&
+      this.allowedOrigins.indexOf(event.origin) === -1
+    ) {
       console.error(`${event.origin} is not in the list of known origins`);
       return;
     }
 
-    const payload = event.data as { type: EventType, value: any, from?: string[], to?: string[] };
+    const payload = event.data as {
+      type: EventType;
+      value: any;
+      from?: string[];
+      to?: string[];
+    };
 
     // we ignore LOADING SUCCESS as it is handled by the outlet component itself
     if (payload.type === SHELL_EVENTS.Version1.OUTLET.LOADING_SUCCESS) {
@@ -192,35 +227,55 @@ export class ShellSdk {
 
     // If current instance is not root, we act as middleman node to propagate
     if (!this.isRoot) {
-
       // Message come from a registered outlet, we send to parent (this.target) with a `from` value
       const source: Window = <Window>event.source;
 
-      if (source) { // If has a source, we look if it come from one of our HTMLIFrameElement
-        const iFrameElement = Array.from(this.outletsMap.keys()).find(frame => frame.contentWindow === source);
-        if (iFrameElement) {  // If it come from an outlet
+      if (source) {
+        // If has a source, we look if it come from one of our HTMLIFrameElement
+        const iFrameElement = Array.from(this.outletsMap.keys()).find(
+          (frame) => frame.contentWindow === source
+        );
+        if (iFrameElement) {
+          // If it come from an outlet
           if (payload.type == SHELL_EVENTS.Version1.SET_VIEW_STATE) {
-            throw new Error('[ShellSDk] A plugin tried to update viewState using SetViewState which is not allowed for security reason.');
+            throw new Error(
+              '[ShellSDk] A plugin tried to update viewState using SetViewState which is not allowed for security reason.'
+            );
           }
           let from = payload.from || [];
           // If we receive from outlet request_context to fetch plugin from target, we return LOADING_FAIL
           // if too many depth exchanges
-          if (payload.type == SHELL_EVENTS.Version1.OUTLET.REQUEST_CONTEXT &&
-              from.length >= this.outletMaximumDepth) {
-            source.postMessage({
-              type: SHELL_EVENTS.Version1.OUTLET.LOADING_FAIL,
-              value: {
-                target: payload.value.target,
-                error: ErrorType.OUTLET_MAXIMUM_DEPTH
+          if (
+            payload.type == SHELL_EVENTS.Version1.OUTLET.REQUEST_CONTEXT &&
+            from.length >= this.outletMaximumDepth
+          ) {
+            source.postMessage(
+              {
+                type: SHELL_EVENTS.Version1.OUTLET.LOADING_FAIL,
+                value: {
+                  target: payload.value.target,
+                  error: ErrorType.OUTLET_MAXIMUM_DEPTH,
+                },
+                to: from,
               },
-              to: from
-            }, this.origin);
+              this.origin
+            );
           } else {
             const uuid = this.outletsMap.get(iFrameElement);
-            if (uuid) { // this is the uuid outlet used for routing of source object
+            if (uuid) {
+              // this is the uuid outlet used for routing of source object
               from = [...from, uuid];
-              this.debugger.traceEvent('outgoing', payload.type, payload.value, { from }, true);
-              this.target.postMessage({ type: payload.type, value: payload.value, from }, this.origin);
+              this.debugger.traceEvent(
+                'outgoing',
+                payload.type,
+                payload.value,
+                { from },
+                true
+              );
+              this.target.postMessage(
+                { type: payload.type, value: payload.value, from },
+                this.origin
+              );
             }
           }
           return;
@@ -234,12 +289,21 @@ export class ShellSdk {
       if (payload.type == SHELL_EVENTS.Version1.SET_VIEW_STATE) {
         this.outletsMap.forEach((value, key) => {
           if (key.contentWindow) {
-            key.contentWindow.postMessage({ type: payload.type, value: payload.value }, this.origin);
+            key.contentWindow.postMessage(
+              { type: payload.type, value: payload.value },
+              this.origin
+            );
           }
         });
 
         const subscribers = this.subscribersViewStateMap.get(payload.value.key);
-        this.debugger.traceEvent('incoming', payload.type, payload.value, {}, !!subscribers);
+        this.debugger.traceEvent(
+          'incoming',
+          payload.type,
+          payload.value,
+          {},
+          !!subscribers
+        );
         if (!!subscribers) {
           for (const subscriber of subscribers) {
             subscriber(payload.value.value);
@@ -249,23 +313,49 @@ export class ShellSdk {
       }
 
       // If ShellSdk receive OUTLET.REQUEST_CONTEXT with only `isConfigurationMode` we propagate to all outlets
-      if (payload.type == SHELL_EVENTS.Version1.OUTLET.REQUEST_CONTEXT &&
-          payload.value.hasOwnProperty('isConfigurationMode') &&
-          !payload.value.hasOwnProperty('target') &&
-          !payload.value.hasOwnProperty('plugin')) {
+      if (
+        payload.type == SHELL_EVENTS.Version1.OUTLET.REQUEST_CONTEXT &&
+        payload.value.hasOwnProperty('isConfigurationMode') &&
+        !payload.value.hasOwnProperty('target') &&
+        !payload.value.hasOwnProperty('plugin')
+      ) {
         this.outletsMap.forEach((value, key) => {
           if (key.contentWindow) {
-            key.contentWindow.postMessage({ type: payload.type, value: payload.value }, this.origin);
+            key.contentWindow.postMessage(
+              { type: payload.type, value: payload.value },
+              this.origin
+            );
           }
         });
       }
 
       // Message has a `to` value, send to an outlet as one to one communication
-      if (payload.to && payload.to.length != 0 && payload.type !== SHELL_EVENTS.Version1.TO_APP) {
-        this.debugger.traceEvent('outgoing', payload.type, payload.value, { to: payload.to }, true);
+      if (
+        payload.to &&
+        payload.to.length != 0 &&
+        payload.type !== SHELL_EVENTS.Version1.TO_APP
+      ) {
+        this.debugger.traceEvent(
+          'outgoing',
+          payload.type,
+          payload.value,
+          { to: payload.to },
+          true
+        );
         this.outletsMap.forEach((value, key) => {
-          if (payload.to && payload.to.indexOf(value) !== -1 && key.contentWindow) {
-            key.contentWindow.postMessage({ type: payload.type, value: payload.value, to: payload.to.filter(id => id != value) }, this.origin);
+          if (
+            payload.to &&
+            payload.to.indexOf(value) !== -1 &&
+            key.contentWindow
+          ) {
+            key.contentWindow.postMessage(
+              {
+                type: payload.type,
+                value: payload.value,
+                to: payload.to.filter((id) => id != value),
+              },
+              this.origin
+            );
           }
         });
         return;
@@ -274,14 +364,22 @@ export class ShellSdk {
 
     // If isRoot or message is for me, we send to subscribers/handlers
     const subscribers = this.subscribersMap.get(payload.type);
-    this.debugger.traceEvent('incoming', payload.type, payload.value, { from: payload.from }, !!subscribers);
+    this.debugger.traceEvent(
+      'incoming',
+      payload.type,
+      payload.value,
+      { from: payload.from },
+      !!subscribers
+    );
 
     if (!!subscribers) {
       for (const subscriber of subscribers) {
         subscriber(
           payload.value,
           event.origin,
-          payload.type == SHELL_EVENTS.Version1.SET_VIEW_STATE ? null : payload.from
+          payload.type == SHELL_EVENTS.Version1.SET_VIEW_STATE
+            ? null
+            : payload.from
         );
       }
     }
@@ -289,9 +387,12 @@ export class ShellSdk {
     // On REQUIRE_CONTEXT, we split and propagate viewState
     // Need to be done AFTER REQUIRE_CONTEXT event in case of plugin need auth or context.
     if (!this.isRoot && payload.type == SHELL_EVENTS.Version1.REQUIRE_CONTEXT) {
-      const context = typeof(payload.value) == 'string' ? JSON.parse(payload.value) : payload.value;
+      const context =
+        typeof payload.value == 'string'
+          ? JSON.parse(payload.value)
+          : payload.value;
       const viewState = context.viewState;
-      if (viewState) {        
+      if (viewState) {
         for (let key of Object.keys(viewState)) {
           const subscribers = this.subscribersViewStateMap.get(`${key}`);
           if (!!subscribers) {
@@ -301,7 +402,10 @@ export class ShellSdk {
           }
         }
       }
-      this.target.postMessage({ type: SHELL_EVENTS.Version1.OUTLET.LOADING_SUCCESS }, this.origin);
+      this.target.postMessage(
+        { type: SHELL_EVENTS.Version1.OUTLET.LOADING_SUCCESS },
+        this.origin
+      );
     }
-  }
+  };
 }


### PR DESCRIPTION
This PR provide a way to access ShellSdk target object. This usecase occured on cs-ngx-iframe library which needs to send a message to such target, being window.parent most of the case but having an official getter would allow testing with spies and strong code validation. 

A unittest has been added.
Also code linting done by prettier, more to come about that sorry will make it harder to review.

> TOTAL: 22 SUCCESS
>
> Finished in 0.047 secs / 0.023 secs @ 12:41:45 GMT+0200 (Central European Summer Time)
>
> SUMMARY:
> ✔ 22 tests completed