### PR TITLE
Allow `OutletsRequestContextRequest` message to show/hide mocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.0] - 2020-08-04
+
+### Added
+
+- Allow `OutletsRequestContextRequest` message to show/hide mocks on `V1.OUTLET.ADD_PLUGIN` event
+
 ## [1.5.1] - 2020-06-17
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fsm-shell",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "description": "client library for FSM shell",
   "main": "release/fsm-shell-client.js",
   "module": "release/fsm-shell-client.es.js",

--- a/src/models/outlets/outlets-request-context-request.model.ts
+++ b/src/models/outlets/outlets-request-context-request.model.ts
@@ -1,3 +1,4 @@
 export interface OutletsRequestContextRequest<T> {
   target: string;
+  showMocks?: boolean;
 }


### PR DESCRIPTION
This PR add a boolean to the OutletsRequestContextRequest so shell knows if it should return or not the mocked plug-ins for testing purpose.

This will allow us to load them on production on the integration-test page 👍 