### PR TITLE
[CPB-65865][SHELL] - enhance the REQUIRE_CONTEXT event to retrieve th…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.12.1] - 2021-08-11
+
+### Fixed
+
+- Context with deploymentId for extensions only works in case the respective outlet has a target (name), which is optional. Execute logic to retrieve deploymentId only in case respective outlet has a target.
+
 ## [1.12.0] - 2021-08-02
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fsm-shell",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fsm-shell",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "description": "client library for FSM shell",
   "main": "release/fsm-shell-client.js",
   "module": "release/fsm-shell-client.es.js",

--- a/src/ShellSdk.ts
+++ b/src/ShellSdk.ts
@@ -158,7 +158,7 @@ export class ShellSdk {
 
   // Called by outlet component to assign an generated uuid to an iframe. This is key
   // to allow one to one communication between a pluging and shell-host
-  public registerOutlet(frame: HTMLIFrameElement, _name: string) {
+  public registerOutlet(frame: HTMLIFrameElement, _name: string | undefined) {
     this.outletsMap.set(frame, {
       uuid: uuidv4(),
       name: _name,
@@ -380,7 +380,8 @@ export class ShellSdk {
             if (outlet && outlet.uuid) {
               if (
                 payload.type === SHELL_EVENTS.Version1.REQUIRE_CONTEXT &&
-                from.length === 0
+                from.length === 0 &&
+                outlet.name !== undefined
               ) {
                 payload.value.targetOutletName = outlet.name;
               }

--- a/src/models/outlets/outlet.model.ts
+++ b/src/models/outlets/outlet.model.ts
@@ -1,4 +1,4 @@
 export interface Outlet {
   uuid: string;
-  name: string;
+  name: string | undefined;
 }

--- a/src/tests/Outlets.spec.ts
+++ b/src/tests/Outlets.spec.ts
@@ -414,62 +414,126 @@ describe('Outlets', () => {
     expect(postMessageOutlet.called).toBe(true);
   });
 
-  it('should add the target outlet name for message SHELL_EVENTS.Version1.REQUIRE_CONTEXT from an extension', () => {
-    let type: any;
-    let value: any;
-    let origin: string;
-    let from: string[];
+  it(
+    'should add the target outlet name for message SHELL_EVENTS.Version1.REQUIRE_CONTEXT from an extension' +
+      'in case target outlet name is defined',
+    () => {
+      let type: any;
+      let value: any;
+      let origin: string;
+      let from: string[];
 
-    const POST_MESSAGE_PARENT = sinon.spy((payload, _origin) => {
-      type = payload.type;
-      value = payload.value;
-      from = payload.from;
-      origin = _origin;
-    });
-    sdk = ShellSdk.init(
-      {
-        postMessage: POST_MESSAGE_PARENT,
-      } as any as Window,
-      sdkOrigin,
-      windowMock,
-      null,
-      3
-    );
+      const POST_MESSAGE_PARENT = sinon.spy((payload, _origin) => {
+        type = payload.type;
+        value = payload.value;
+        from = payload.from;
+        origin = _origin;
+      });
+      sdk = ShellSdk.init(
+        {
+          postMessage: POST_MESSAGE_PARENT,
+        } as any as Window,
+        sdkOrigin,
+        windowMock,
+        null,
+        3
+      );
 
-    // postMessage catch messages send to outlets
-    const POST_MESSAGE = sinon.spy();
-    const IFRAME = {
-      src: EXTENSION_SRC,
-      contentWindow: {
-        postMessage: POST_MESSAGE,
-      } as any as Window,
-    } as any as HTMLIFrameElement;
+      // postMessage catch messages send to outlets
+      const POST_MESSAGE = sinon.spy();
+      const IFRAME = {
+        src: EXTENSION_SRC,
+        contentWindow: {
+          postMessage: POST_MESSAGE,
+        } as any as Window,
+      } as any as HTMLIFrameElement;
 
-    sdk.registerOutlet(IFRAME, TARGET_OUTLET_NAME_1);
+      sdk.registerOutlet(IFRAME, TARGET_OUTLET_NAME_1);
 
-    windowMockCallback({
-      data: {
-        type: SHELL_EVENTS.Version1.REQUIRE_CONTEXT,
-        value: {
-          clientIdentifier: 'example-plugin',
+      windowMockCallback({
+        data: {
+          type: SHELL_EVENTS.Version1.REQUIRE_CONTEXT,
+          value: {
+            clientIdentifier: 'example-plugin',
+          },
         },
-      },
-      origin: EXTENSION_ORIGIN,
-      source: IFRAME.contentWindow,
-    });
+        origin: EXTENSION_ORIGIN,
+        source: IFRAME.contentWindow,
+      });
 
-    const OUTLET = (sdk as any).outletsMap.get(IFRAME);
+      const OUTLET = (sdk as any).outletsMap.get(IFRAME);
 
-    expect(POST_MESSAGE.called).toBe(false);
-    expect(POST_MESSAGE_PARENT.called).toBe(true);
-    expect(type).toEqual(SHELL_EVENTS.Version1.REQUIRE_CONTEXT);
-    expect(value).toEqual({
-      clientIdentifier: 'example-plugin',
-      targetOutletName: OUTLET.name,
-    });
-    expect(from).toEqual([OUTLET.uuid]);
-    expect(origin).toEqual(sdkOrigin);
-  });
+      expect(POST_MESSAGE.called).toBe(false);
+      expect(POST_MESSAGE_PARENT.called).toBe(true);
+      expect(type).toEqual(SHELL_EVENTS.Version1.REQUIRE_CONTEXT);
+      expect(value).toEqual({
+        clientIdentifier: 'example-plugin',
+        targetOutletName: OUTLET.name,
+      });
+      expect(from).toEqual([OUTLET.uuid]);
+      expect(origin).toEqual(sdkOrigin);
+    }
+  );
+
+  it(
+    'should not add the target outlet name for message SHELL_EVENTS.Version1.REQUIRE_CONTEXT from an extension' +
+      'in case target outlet name is undefined',
+    () => {
+      let type: any;
+      let value: any;
+      let origin: string;
+      let from: string[];
+
+      const POST_MESSAGE_PARENT = sinon.spy((payload, _origin) => {
+        type = payload.type;
+        value = payload.value;
+        from = payload.from;
+        origin = _origin;
+      });
+      sdk = ShellSdk.init(
+        {
+          postMessage: POST_MESSAGE_PARENT,
+        } as any as Window,
+        sdkOrigin,
+        windowMock,
+        null,
+        3
+      );
+
+      // postMessage catch messages send to outlets
+      const POST_MESSAGE = sinon.spy();
+      const IFRAME = {
+        src: EXTENSION_SRC,
+        contentWindow: {
+          postMessage: POST_MESSAGE,
+        } as any as Window,
+      } as any as HTMLIFrameElement;
+
+      sdk.registerOutlet(IFRAME, undefined);
+
+      windowMockCallback({
+        data: {
+          type: SHELL_EVENTS.Version1.REQUIRE_CONTEXT,
+          value: {
+            clientIdentifier: 'example-plugin',
+          },
+        },
+        origin: EXTENSION_ORIGIN,
+        source: IFRAME.contentWindow,
+      });
+
+      const OUTLET = (sdk as any).outletsMap.get(IFRAME);
+
+      expect(POST_MESSAGE.called).toBe(false);
+      expect(POST_MESSAGE_PARENT.called).toBe(true);
+      expect(type).toEqual(SHELL_EVENTS.Version1.REQUIRE_CONTEXT);
+      expect(value).toEqual({
+        clientIdentifier: 'example-plugin',
+      });
+      expect(from).toEqual([OUTLET.uuid]);
+      expect(origin).toEqual(sdkOrigin);
+    }
+  );
 
   it('should not override target outlet name for message SHELL_EVENTS.Version1.REQUIRE_CONTEXT from an extension', () => {
     let type: any;


### PR DESCRIPTION
…e extension deployment id

Context with deploymentId for extensions only works in case the respective outlet has a target (name), which is optional. Execute logic to retrieve deploymentId only in case respective outlet has a target.