### PR TITLE
Validate max depth for dynamic outlets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.15.3] - 2022-01-11
+
+### Fixed
+
+- Validate max depth for OUTLETS.REQUEST_DYNAMIC_CONTEXT event
+
 ## [1.15.2] - 2021-12-07
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fsm-shell",
-  "version": "1.15.2",
+  "version": "1.15.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fsm-shell",
-  "version": "1.15.2",
+  "version": "1.15.3",
   "description": "client library for FSM shell",
   "main": "release/fsm-shell-client.js",
   "module": "release/fsm-shell-client.es.js",

--- a/src/ShellSdk.ts
+++ b/src/ShellSdk.ts
@@ -416,10 +416,12 @@ export class ShellSdk {
             console.warn('[ShellSDk] MODAL OPEN url is not in allowedList.');
             return;
           }
-          // If we receive from outlet request_context to fetch plugin from target, we return LOADING_FAIL
-          // if too many depth exchanges
+          // If ShellSdk receives from outlet REQUEST_CONTEXT or from dynamic outlet REQUEST_DYNAMIC_CONTEXT
+          // to fetch plugin(s) from target, return LOADING_FAIL if too many depth exchanges.
           if (
-            payload.type === SHELL_EVENTS.Version1.OUTLET.REQUEST_CONTEXT &&
+            (payload.type === SHELL_EVENTS.Version1.OUTLET.REQUEST_CONTEXT ||
+              payload.type ===
+                SHELL_EVENTS.Version1.OUTLET.REQUEST_DYNAMIC_CONTEXT) &&
             from.length >= this.outletMaximumDepth
           ) {
             source.postMessage(

--- a/src/tests/Outlets.spec.ts
+++ b/src/tests/Outlets.spec.ts
@@ -423,62 +423,127 @@ describe('Outlets', () => {
     }
   );
 
-  it('should return SHELL_EVENTS.Version1.OUTLET.LOADING_FAIL if reached maximum depth', () => {
-    const postMessageParent = sinon.spy();
-    sdk = ShellSdk.init(
-      {
-        postMessage: postMessageParent,
-      } as any as Window,
-      sdkOrigin,
-      windowMock,
-      null,
-      3
-    );
+  it(
+    'should return SHELL_EVENTS.Version1.OUTLET.LOADING_FAIL if payload type is ' +
+      'SHELL_EVENTS.Version1.OUTLET.REQUEST_CONTEXT and reached maximum depth',
+    () => {
+      const postMessageParent = sinon.spy();
+      sdk = ShellSdk.init(
+        {
+          postMessage: postMessageParent,
+        } as any as Window,
+        sdkOrigin,
+        windowMock,
+        null,
+        3
+      );
 
-    let handleMessage = sinon.spy();
-    sdk.on(SHELL_EVENTS.Version1.OUTLET.LOADING_FAIL, handleMessage);
+      let handleMessage = sinon.spy();
+      sdk.on(SHELL_EVENTS.Version1.OUTLET.LOADING_FAIL, handleMessage);
 
-    const postMessageOutlet = sinon.spy();
-    const iframe = {
-      src: EXTENSION_SRC,
-      contentWindow: {
-        postMessage: postMessageOutlet,
-      } as any as Window,
-    } as any as HTMLIFrameElement;
-    sdk.registerOutlet(iframe, TARGET_OUTLET_NAME_1);
+      const postMessageOutlet = sinon.spy();
+      const iframe = {
+        src: EXTENSION_SRC,
+        contentWindow: {
+          postMessage: postMessageOutlet,
+        } as any as Window,
+      } as any as HTMLIFrameElement;
+      sdk.registerOutlet(iframe, TARGET_OUTLET_NAME_1);
 
-    windowMockCallback({
-      source: iframe.contentWindow,
-      origin: EXTENSION_ORIGIN,
-      data: {
-        type: SHELL_EVENTS.Version1.OUTLET.REQUEST_CONTEXT,
-        value: {
-          target: 'test',
+      windowMockCallback({
+        source: iframe.contentWindow,
+        origin: EXTENSION_ORIGIN,
+        data: {
+          type: SHELL_EVENTS.Version1.OUTLET.REQUEST_CONTEXT,
+          value: {
+            target: 'test',
+          },
+          from: ['a', 'b'],
         },
-        from: ['a', 'b'],
-      },
-    });
+      });
 
-    expect(postMessageParent.called).toBe(true);
-    expect(postMessageOutlet.called).toBe(false);
-    postMessageParent.resetHistory();
-    postMessageOutlet.resetHistory();
+      expect(postMessageParent.called).toBe(true);
+      expect(postMessageOutlet.called).toBe(false);
+      postMessageParent.resetHistory();
+      postMessageOutlet.resetHistory();
 
-    windowMockCallback({
-      source: iframe.contentWindow,
-      origin: EXTENSION_ORIGIN,
-      data: {
-        type: SHELL_EVENTS.Version1.OUTLET.REQUEST_CONTEXT,
-        value: {
-          target: 'test',
+      windowMockCallback({
+        source: iframe.contentWindow,
+        origin: EXTENSION_ORIGIN,
+        data: {
+          type: SHELL_EVENTS.Version1.OUTLET.REQUEST_CONTEXT,
+          value: {
+            target: 'test',
+          },
+          from: ['a', 'b', 'c'],
         },
-        from: ['a', 'b', 'c'],
-      },
-    });
+      });
 
-    expect(postMessageParent.called).toBe(false);
-    expect(postMessageOutlet.called).toBe(true);
-  });
+      expect(postMessageParent.called).toBe(false);
+      expect(postMessageOutlet.called).toBe(true);
+    }
+  );
+
+  it(
+    'should return SHELL_EVENTS.Version1.OUTLET.LOADING_FAIL if payload type is ' +
+      'SHELL_EVENTS.Version1.OUTLET.REQUEST_DYNAMIC_CONTEXT and reached maximum depth',
+    () => {
+      const postMessageParent = sinon.spy();
+      sdk = ShellSdk.init(
+        {
+          postMessage: postMessageParent,
+        } as any as Window,
+        sdkOrigin,
+        windowMock,
+        null,
+        3
+      );
+
+      let handleMessage = sinon.spy();
+      sdk.on(SHELL_EVENTS.Version1.OUTLET.LOADING_FAIL, handleMessage);
+
+      const postMessageOutlet = sinon.spy();
+      const iframe = {
+        src: EXTENSION_SRC,
+        contentWindow: {
+          postMessage: postMessageOutlet,
+        } as any as Window,
+      } as any as HTMLIFrameElement;
+      sdk.registerOutlet(iframe, TARGET_OUTLET_NAME_1);
+
+      windowMockCallback({
+        source: iframe.contentWindow,
+        origin: EXTENSION_ORIGIN,
+        data: {
+          type: SHELL_EVENTS.Version1.OUTLET.REQUEST_DYNAMIC_CONTEXT,
+          value: {
+            target: 'test',
+          },
+          from: ['a', 'b'],
+        },
+      });
+
+      expect(postMessageParent.called).toBe(true);
+      expect(postMessageOutlet.called).toBe(false);
+      postMessageParent.resetHistory();
+      postMessageOutlet.resetHistory();
+
+      windowMockCallback({
+        source: iframe.contentWindow,
+        origin: EXTENSION_ORIGIN,
+        data: {
+          type: SHELL_EVENTS.Version1.OUTLET.REQUEST_DYNAMIC_CONTEXT,
+          value: {
+            target: 'test',
+          },
+          from: ['a', 'b', 'c'],
+        },
+      });
+
+      expect(postMessageParent.called).toBe(false);
+      expect(postMessageOutlet.called).toBe(true);
+    }
+  );
 
   it(
     'should add the target outlet name for message SHELL_EVENTS.Version1.REQUIRE_CONTEXT from an extension' +


### PR DESCRIPTION
Validate max depth for dynamic outlets. In case max depth is exceeded block Shell event Version1.OUTLET.REQUEST_DYNAMIC_CONTEXT and return error instead.