### PR TITLE
Add backdropClickCloseable field as part of modalSettings in payload …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.15.4] - 2022-05-18
+
+### Added
+
+- Add backdropClickCloseable field as part of modalSettings in payload for MODAL.OPEN event
+
 ## [1.15.3] - 2022-01-11
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fsm-shell",
-  "version": "1.15.3",
+  "version": "1.15.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fsm-shell",
-  "version": "1.15.3",
+  "version": "1.15.4",
   "description": "client library for FSM shell",
   "main": "release/fsm-shell-client.js",
   "module": "release/fsm-shell-client.es.js",

--- a/src/models/modal/modal-open-request.model.ts
+++ b/src/models/modal/modal-open-request.model.ts
@@ -4,5 +4,6 @@ export interface ModalOpenRequest {
   modalSettings?: {
     title?: string;
     size?: ModalSize;
+    backdropClickCloseable?: boolean;
   };
 }

--- a/src/validation/schemas/modal/modal-open-request.v1.schema.ts
+++ b/src/validation/schemas/modal/modal-open-request.v1.schema.ts
@@ -14,6 +14,9 @@ export const modalOpenRequest_v1_schema = {
           type: 'string',
           enum: ['l', 'm', 's'],
         },
+        backdropClickCloseable: {
+          type: 'boolean',
+        },
       },
     },
   },


### PR DESCRIPTION
…for MODAL.OPEN event

backdropClickCloseable allows to configure the backdrop for the app inside the iFrame as closable on click or not closable on click