### PR TITLE
Add isScrollbarHidden field as part of modalSettings in payload for M…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.15.5] - 2022-05-24
+
+### Added
+
+- Add isScrollbarHidden field as part of modalSettings in payload for MODAL.OPEN event
+
 ## [1.15.4] - 2022-05-18
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fsm-shell",
-  "version": "1.15.4",
+  "version": "1.15.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fsm-shell",
-  "version": "1.15.4",
+  "version": "1.15.5",
   "description": "client library for FSM shell",
   "main": "release/fsm-shell-client.js",
   "module": "release/fsm-shell-client.es.js",

--- a/src/models/modal/modal-open-request.model.ts
+++ b/src/models/modal/modal-open-request.model.ts
@@ -5,5 +5,6 @@ export interface ModalOpenRequest {
     title?: string;
     size?: ModalSize;
     backdropClickCloseable?: boolean;
+    isScrollbarHidden?: boolean;
   };
 }

--- a/src/validation/schemas/modal/modal-open-request.v1.schema.ts
+++ b/src/validation/schemas/modal/modal-open-request.v1.schema.ts
@@ -17,6 +17,9 @@ export const modalOpenRequest_v1_schema = {
         backdropClickCloseable: {
           type: 'boolean',
         },
+        isScrollbarHidden: {
+          type: 'boolean',
+        },
       },
     },
   },


### PR DESCRIPTION
…ODAL.OPEN event

Property isScrollbarHidden allows to configure the Shell modal w or w/o default scrollbar. In case default scrollbar is disabled, custom scrollbar should be defined for the content inside the Shell modal.