### PR TITLE
[CPB-77994] Fixed isInsideShellModal always returning false.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.15.7] - 2022-08-24
+
+### Fixed
+
+- isInsideShellModal() method always returning false
+
 ## [1.15.6] - 2022-08-03
 
 ### Updated

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fsm-shell",
-  "version": "1.15.6",
+  "version": "1.15.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fsm-shell",
-  "version": "1.15.6",
+  "version": "1.15.7",
   "description": "client library for FSM shell",
   "main": "release/fsm-shell-client.js",
   "module": "release/fsm-shell-client.es.js",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   ],
   "scripts": {
     "build": "rollup -c",
+    "watch": "rollup -w -c",
     "prebuild": "npm run clean && node ./scripts/createVersionInfo",
     "clean": "rm -rf release",
     "version": "node ./scripts/version.js > ./version.txt",

--- a/src/ShellSdk.spec.ts
+++ b/src/ShellSdk.spec.ts
@@ -452,9 +452,6 @@ describe('Shell Sdk', () => {
   });
 
   it('IsInsideShellModal() return true when REQUIRE_CONTEXT has isInsideShellModal: true', () => {
-    let technicianId: number;
-    let servicecallId: number;
-
     sdk = ShellSdk.init(sdkTarget, sdkOrigin, windowMock);
 
     windowMockCallback({
@@ -468,6 +465,37 @@ describe('Shell Sdk', () => {
     });
 
     expect(sdk.isInsideShellModal()).toEqual(true);
+  });
+
+  it('IsInsideShellModal() return false when REQUIRE_CONTEXT has no isInsideShellModal property', () => {
+    sdk = ShellSdk.init(sdkTarget, sdkOrigin, windowMock);
+
+    windowMockCallback({
+      data: {
+        type: SHELL_EVENTS.Version1.REQUIRE_CONTEXT,
+        value: {
+          message: 'test data',
+        },
+      },
+    });
+
+    expect(sdk.isInsideShellModal()).toEqual(false);
+  });
+
+  it('IsInsideShellModal() return false when instantiated as root', () => {
+    sdk = ShellSdk.init(null as any as Window, sdkOrigin, windowMock);
+
+    windowMockCallback({
+      data: {
+        type: SHELL_EVENTS.Version1.REQUIRE_CONTEXT,
+        value: {
+          message: 'test data',
+          isInsideShellModal: true,
+        },
+      },
+    });
+
+    expect(sdk.isInsideShellModal()).toEqual(false);
   });
 
   it('should ignore events from IgnoredOrigins', () => {

--- a/src/ShellSdk.ts
+++ b/src/ShellSdk.ts
@@ -562,6 +562,18 @@ export class ShellSdk {
       !!subscribers
     );
 
+    let context = null;
+    if (
+      !this.isRoot &&
+      payload.type === SHELL_EVENTS.Version1.REQUIRE_CONTEXT
+    ) {
+      context =
+        typeof payload.value === 'string'
+          ? JSON.parse(payload.value)
+          : payload.value;
+      this.isInsideModal = !!context.isInsideShellModal;
+    }
+
     if (!!subscribers) {
       for (const subscriber of subscribers) {
         subscriber(
@@ -581,12 +593,7 @@ export class ShellSdk {
       !this.isRoot &&
       payload.type === SHELL_EVENTS.Version1.REQUIRE_CONTEXT
     ) {
-      const context =
-        typeof payload.value === 'string'
-          ? JSON.parse(payload.value)
-          : payload.value;
       const viewState = context.viewState;
-      this.isInsideModal = !!context.isInsideShellModal;
       if (viewState) {
         for (const key of Object.keys(viewState)) {
           const thisSubscribers = this.subscribersViewStateMap.get(`${key}`);


### PR DESCRIPTION
Assigned this.isInsideModal before calling subscriber functions.
Incremented version.
Added watch command for rollup.