### PR TITLE
updating the product name in the docs

### DIFF
--- a/.github/workflows/fsh-shell_pull-request.yml
+++ b/.github/workflows/fsh-shell_pull-request.yml
@@ -4,22 +4,14 @@ run-name: '[ON_PR fsm-shell] ${{ github.sha }}'
 on:
   pull_request:
     branches: [master]
-    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 jobs:
   ensure-mandatory-files:
     runs-on: ubuntu-latest
     continue-on-error: true # Some changes are only relevant for the documentation page
     steps:
-      - name: Skip if label 'skip-ensure-mandatory-files' is present
-        if: contains(github.event.pull_request.labels.*.name, 'skip-ensure-mandatory-files')
-        run: |
-          echo "Label 'skip-ensure-mandatory-files' detected, skipping check."
-          exit 0
       - uses: actions/checkout@v4
-        if: "!contains(github.event.pull_request.labels.*.name, 'skip-ensure-mandatory-files')"
       - name: Check
-        if: "!contains(github.event.pull_request.labels.*.name, 'skip-ensure-mandatory-files')"
         env:
           REQUIRED_FILES: CHANGELOG.md package.json package-lock.json
         run: |

--- a/.github/workflows/fsh-shell_pull-request.yml
+++ b/.github/workflows/fsh-shell_pull-request.yml
@@ -6,6 +6,7 @@ on:
     branches: [master]
     types: [opened, synchronize, reopened, labeled, unlabeled]
 
+
 jobs:
   ensure-mandatory-files:
     runs-on: ubuntu-latest

--- a/.github/workflows/fsh-shell_pull-request.yml
+++ b/.github/workflows/fsh-shell_pull-request.yml
@@ -4,14 +4,22 @@ run-name: '[ON_PR fsm-shell] ${{ github.sha }}'
 on:
   pull_request:
     branches: [master]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 jobs:
   ensure-mandatory-files:
     runs-on: ubuntu-latest
     continue-on-error: true # Some changes are only relevant for the documentation page
     steps:
+      - name: Skip if label 'skip-ensure-mandatory-files' is present
+        if: contains(github.event.pull_request.labels.*.name, 'skip-ensure-mandatory-files')
+        run: |
+          echo "Label 'skip-ensure-mandatory-files' detected, skipping check."
+          exit 0
       - uses: actions/checkout@v4
+        if: "!contains(github.event.pull_request.labels.*.name, 'skip-ensure-mandatory-files')"
       - name: Check
+        if: "!contains(github.event.pull_request.labels.*.name, 'skip-ensure-mandatory-files')"
         env:
           REQUIRED_FILES: CHANGELOG.md package.json package-lock.json
         run: |

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![npm version](https://badge.fury.io/js/fsm-shell.svg)](https://badge.fury.io/js/fsm-shell)
 [![REUSE status](https://api.reuse.software/badge/github.com/Sap/fsm-shell)](https://api.reuse.software/info/github.com/Sap/fsm-shell)
 
-# Client library for applications rendered in FSM shell host
+# Client library for applications rendered in SAP Field Servive and Asset Management Shell Host
 
 ## How to use ShellSdk
 
@@ -34,13 +34,13 @@ Current instance also use [mermaid](https://mermaidjs.github.io/#/) for diagrams
 
 ### e2e tests on documentation
 
-End to end tests can be runned on docsify documentation using `npm run docs` then `npm run e2e`.
+End to end tests can be run on docsify documentation using `npm run docs` then `npm run e2e`.
 
 Documentation server will start before tests running `npm run e2e:ci`
 
 ## Support
 
-In case you need further help, check out the [SAP Field Service Management Help Portal](https://help.sap.com/viewer/product/SAP_FIELD_SERVICE_MANAGEMENT/Cloud/en-US) or report and incident in [SAP Support Portal](https://support.sap.com) with the component "CEC-SRV-FSM".
+In case you need further help, check out the [SAP Field Service and Asset Management Help Portal](https://help.sap.com/viewer/product/SAP_FIELD_SERVICE_MANAGEMENT/Cloud/en-US) or report and incident in [SAP Support Portal](https://support.sap.com) with the component "CEC-SRV-FSM".
 
 ## License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,13 +1,13 @@
-# Client library for applications rendered in FSM shell host
+# Client library for applications rendered in SAP Field Service and Asset Management Shell Host
 
 [![Build Status](https://travis-ci.com/SAP/fsm-shell.svg?branch=master)](https://travis-ci.com/SAP/fsm-shell)
 [![Coverage Status](https://coveralls.io/repos/github/SAP/fsm-shell/badge.svg?branch=master)](https://coveralls.io/github/SAP/fsm-shell?branch=master)
 
 ## Description
 
-[SAP FSM (Field Service Management)](https://www.sap.com/products/field-service-management.html) shell is an extendable Web-Application. FSM shell _host_ is the extendable part of the Web-Application and a FSM shell _client_ is the extension. For more information regarding SAP FSM, check out the [SAP Field Service Management Help Portal](https://help.sap.com/viewer/product/SAP_FIELD_SERVICE_MANAGEMENT/Cloud/en-US).
+[SAP Field Service and Asset Management](https://www.sap.com/products/crm/customer-service/field-service-management.html) Shell is an extendable Web-Application. SAP Field Service and Asset Management Shell _host_ is the extendable part of the Web-Application and a Shell _client_ is the extension.
 
-FSM-SHELL is a library which is designed to be used in FSM shell clients' applications
+FSM-SHELL is a library which is designed to be used in SAP Field Service and Asset Management Shell client applications
 and plugins to communicate with the shell host by using set of predefined events and api described
 below in API Documentation.
 
@@ -23,7 +23,7 @@ Minimal supported JavaScript version: ES5
 
 ## Support
 
-In case you need further help, check out the [SAP Field Service Management Help Portal](https://help.sap.com/viewer/product/SAP_FIELD_SERVICE_MANAGEMENT/Cloud/en-US) or report and incident in [SAP Support Portal](https://support.sap.com) with the component "CEC-SRV-FSM".
+In case you need further help, check out the [SAP Field Service and Asset Management Help Portal](https://help.sap.com/viewer/product/SAP_FIELD_SERVICE_MANAGEMENT/Cloud/en-US) or report and incident in [SAP Support Portal](https://support.sap.com) with the component "CEC-SRV-FSM".
 
 ## License
 

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -45,7 +45,7 @@ Filtering options object may include following keys:
 
 | Key name  | type               | possible values                | description                                                                                                                  |
 | --------- | ------------------ | ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------- |
-| type      | string or string[] | any fsm shell event identifier | include only specific fsm-shell event types                                                                                  |
+| type      | string or string[] | any fsm-shell event identifier | include only specific fsm-shell event types                                                                                  |
 | direction | string             | `incoming`, `outgoing`         | include only received or sent events                                                                                         |
 | component | string             | `fsm-shell`                    | include only events going thru specific component                                                                            |
 | handled   | boolean            | `true` or `false`              | include only events handled by component (component may have no handlers set for specific event type and ignore some events) |

--- a/docs/events.md
+++ b/docs/events.md
@@ -28,7 +28,7 @@ Must be sent on application startup to get initial application context from the 
   }
   ```
 
-  The property `targetOutletName` is automatically added by the FSM Shell when the request originates from an extension within an outlet. It should not be set manually by the extension. The property `cloudStorageKeys` allows you to register user setting keys that would otherwise not be accessible (see `GET_STORAGE_ITEM` and `SET_STORAGE_ITEM` for more information).
+  The property `targetOutletName` is automatically added by the SAP Field Service and Asset Management Shell when the request originates from an extension within an outlet. It should not be set manually by the extension. The property `cloudStorageKeys` allows you to register user setting keys that would otherwise not be accessible (see `GET_STORAGE_ITEM` and `SET_STORAGE_ITEM` for more information).
 
   A `CloudStorageKey` is defined as follows:
 
@@ -108,7 +108,7 @@ Request restricted token for using by an extension
 
 - ### GET_PERMISSIONS
 
-  With this event you can get permission objects. You can find the available permission object types in the FSM admin page in "User Groups -> select an item -> Permissions -> Object Type". [Here](https://help.sap.com/viewer/fsm_admin/Cloud/en-US/permissions-objects.html) you can also find more information about the permission objects.
+  With this event you can get permission objects. You can find the available permission object types in the SAP Field Service and Asset Management Admin app in "User Groups -> select an item -> Permissions -> Object Type". [Here](https://help.sap.com/viewer/fsm_admin/Cloud/en-US/permissions-objects.html) you can also find more information about the permission objects.
 
 <!-- tabs:start -->
 
@@ -118,7 +118,7 @@ Request restricted token for using by an extension
 SHELL_EVENTS.Version3.GET_PERMISSIONS
 ```
 
-Request permissions for specified object from the Shell. The version 3 uses a different permission calculation than the versions 1 and 2: If the user has the permission NONE for a CRUD operation, _false_ is provided for this CRUD operation. If the user has any other permission (ALL, OWN, ORG_LEVEL or any further permission) for a CRUD operation, _true_ is provided for this CRUD operation. Because of this, there is no need for the property _owners_.
+Request permissions for specified object from the Shell. The version 3 uses a different permission calculation than the versions 1 and 2: If the user has the permission NONE for a CRUD operation, _false_ is provided for this CRUD operation. If the user has any other permission (ALL, OWN, ORG*LEVEL or any further permission) for a CRUD operation, \_true* is provided for this CRUD operation. Because of this, there is no need for the property _owners_.
 
 - Request payload
 
@@ -137,7 +137,8 @@ Request permissions for specified object from the Shell. The version 3 uses a di
   ```typescript
   {
     objectName: string; // permission object type
-  } []
+  }
+  [];
   ```
 
 - Response payload
@@ -255,7 +256,7 @@ Request permissions for specified object from the Shell
 
 - ### GET_SETTINGS
 
-  With this event you can get company specific settings. You can find the available settings in the FSM admin page in "Companies -> select a company -> Company Settings". Here you can create your own settings and fetch them with this event. You can also fetch the existing settings, but consider that many of them are more specific to FSM applications and have a internal mapping. Therefore, you can not fetch them with the key of the company settings from the admin page. In case you need some of these settings, then please contact us. [Here](https://help.sap.com/viewer/fsm_admin/Cloud/en-US/companies.html) you can find more information about companies.
+  With this event you can get company specific settings. You can find the available settings in the SAP Field Service and Asset Management Admin app in "Companies -> select a company -> Company Settings". Here you can create your own settings and fetch them with this event. You can also fetch the existing settings, but consider that many of them are more specific to FSA applications and have an internal mapping. Therefore, you can not fetch them with the key of the company settings from the admin page. In case you need some of these settings, then please contact us. [Here](https://help.sap.com/viewer/fsm_admin/Cloud/en-US/companies.html) you can find more information about companies.
 
   ```
   SHELL_EVENTS.Version1.GET_SETTINGS
@@ -290,25 +291,34 @@ Request permissions for specified object from the Shell
     ```
 
     To fetch `key_1`, it is sufficient to provide the key as a string:
+
     ```typescript
-    'key_1'
+    'key_1';
     ```
 
     To fetch multiple keys, provide them as an array:
+
     ```typescript
-    ['key_1', 'key_2']
+    ['key_1', 'key_2'];
     ```
 
     To fetch nested keys, the path must be defined as an array. To distinguish nested keys from a simple array of keys, the path is wrapped in its own array:
+
     ```typescript
-    [['folder_1', 'key_3']]
+    [['folder_1', 'key_3']];
     ```
 
     `Hint`: Nested keys can have any depth.
 
     It is also possible to fetch multiple keys and multiple nested keys in a single request:
+
     ```typescript
-    ['key_1', 'key_2', ['folder_1', 'key_3'], ['folder_2', 'folder_3', 'key_4']]
+    [
+      'key_1',
+      'key_2',
+      ['folder_1', 'key_3'],
+      ['folder_2', 'folder_3', 'key_4'],
+    ];
     ```
 
   - Response payload
@@ -349,7 +359,7 @@ Request permissions for specified object from the Shell
 
 - ### GET_STORAGE_ITEM
 
-Retrieve user-specific settings from cloud storage. Available settings can be found in the FSM Admin page under "Users -> select a user -> User Settings". More details: [User Documentation](https://help.sap.com/viewer/fsm_admin/Cloud/en-US/users.html)
+Retrieve user-specific settings from cloud storage. Available settings can be found in the SAP Field Service and Asset Management Admin app under "Users -> select a user -> User Settings". More details: [User Documentation](https://help.sap.com/viewer/fsm_admin/Cloud/en-US/users.html)
 
 <!-- tabs:start -->
 
@@ -425,14 +435,17 @@ Currently, the following keys are supported out of the box:
 The keys listed above are preloaded by the Shell, as they are also used internally. Therefore, they are immediately available.
 
 Keys can be either **company-dependent** or **company-independent**:
+
 - **Company-dependent keys** store a separate value for each company. The value returned depends on the currently selected company.
 - **Company-independent keys** share the same value across all companies.
 
 It is also possible to fetch values for additional keys defined for a user in the Admin app. To do so, the keys must first be **registered** via the `REQUIRE_CONTEXT` event:
+
 - The request payload of `REQUIRE_CONTEXT` includes the optional property `cloudStorageKeys`, which allows you to register non-preloaded keys.
 - Once a key has been registered, its value can be retrieved using `Version2.GET_STORAGE_ITEM`.
 
 The event `REQUIRE_CONTEXT` also allows you to register non-existing keys, which is useful for key-value pairs created at runtime:
+
 - After registering a non-existing key, it can be accessed via `Version2.GET_STORAGE_ITEM`.
 - As long as the key-value pair has not been created, the returned value will be `null`.
 - Once the key-value pair is created and becomes visible in the Admin app, the actual value will be returned.
@@ -469,8 +482,9 @@ Registering keys via the `REQUIRE_CONTEXT` event will only be required for non-e
     flag indicating if value was saved successfully
 
   Only key-value pairs that are **preloaded by the Shell** can be updated directly. Other user settings must first be registered via the `REQUIRE_CONTEXT` event before they can be updated using `SET_STORAGE_ITEM` (see `GET_STORAGE_ITEM` for more details).
-  
+
   It is also possible to create new user settings:
+
   - Like non-preloaded settings, new keys must first be registered via `REQUIRE_CONTEXT`.
   - Once registered, they can be created and assigned a value using `SET_STORAGE_ITEM`.
 
@@ -482,7 +496,7 @@ Registering keys via the `REQUIRE_CONTEXT` event will only be required for non-e
 
 - ### GET_FEATURE_FLAG
 
-  Feature flags are internally used flags in FSM to control some new features when the preview mode is off.
+  Feature flags are internally used flags in SAP Field Service and Asset Management to control some new features when the preview mode is off.
 
   ```
   SHELL_EVENTS.Version1.GET_FEATURE_FLAG
@@ -511,7 +525,8 @@ Registering keys via the `REQUIRE_CONTEXT` event will only be required for non-e
   {
     key: string;
     defaultValue: boolean;
-  }[]
+  }
+  [];
   ```
 
 - Response payload

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -18,7 +18,7 @@ exception will be raised and event to the host application will not be sent.
 
 ## Providing validation library
 
-Application consuming fsm shell library can provide validation logic based on external JSON schema
+Application consuming the fsm-shell library can provide validation logic based on external JSON schema
 validation library by service which implements `PayloadValidator` interface defined in fsm-shell
 
 `PayloadValidator` interface has following definition
@@ -57,6 +57,7 @@ where:
   include in this property.
 
 **Important:** All schemas within fsm-shell support the following JSON Schema standards [^1]:
+
 - draft-06
 - draft-07
 


### PR DESCRIPTION
With the 2605 release, SAP Field Service Management (FSM) has been renamed to SAP Field Service and Asset Management (FSA). While technical designations are not affected at this time, this pull request updated all docs with the new name.
[More information](https://help.sap.com/docs/SAP_FIELD_SERVICE_MANAGEMENT/fsm_product_announcements/introduction-of-sap-field-service-and-asset-management.html)